### PR TITLE
Add Basic Auth Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ Perfect for showing birthdays or recurring events from Nextcloud, SOGo, or any o
 
 * Displays **ongoing** and **upcoming** events in separate lists
 * Supports event links (one per widget) (`url`)
+* Supports basic HTTP Authentication (username, password)
 * Configurable limit for collapsible event lists
 * Tested with Nextcloud & SOGo
 * Works with Docker and NixOS
@@ -66,6 +67,8 @@ I May do breaking changes at any time.
 | `limit`          | Number of events returned (applied AFTER ongoing events are prioritized)                      | `5` (omit for all)               |
 | `lookback_days`  | How many days back from now to include events that already started (ensures ongoing coverage) | `14` (default)                   |
 | `horizon_days`   | How many days into the future to fetch (upper bound to limit processing)                      | `3650` (default, ~10 years)      |
+| `username`       | Username to use for basic HTTP authentication                                                 | `admin` (default, null)          |
+| `password`       | Password to use for basic HTTP authentication                                                 | `12345` (default, null)          |
 
 Notes:
 * Ongoing events (already started, not yet ended) are always placed first before upcoming, regardless of `limit`.

--- a/app.py
+++ b/app.py
@@ -1,8 +1,5 @@
-import traceback
-
 from flask import Flask, jsonify, request
 from service import get_events, clamp_int
-from urllib.parse import unquote_plus
 
 app = Flask(__name__)
 
@@ -41,7 +38,6 @@ def calendar_data():
             password=auth_pass
         )
     except Exception as e:
-        traceback.print_exception(e)
         return jsonify({"error": f"Failed to retrieve events: {str(e)}"}), 400
 
     return jsonify({"events": events_out})

--- a/app.py
+++ b/app.py
@@ -1,5 +1,8 @@
+import traceback
+
 from flask import Flask, jsonify, request
 from service import get_events, clamp_int
+from urllib.parse import unquote_plus
 
 app = Flask(__name__)
 
@@ -17,6 +20,8 @@ def calendar_data():
     limit = request.args.get('limit', default=None, type=int)
     lookback_days = request.args.get('lookback_days', default=14, type=int)
     horizon_days = request.args.get('horizon_days', default=3650, type=int)
+    auth_user = request.args.get('username', type=str)
+    auth_pass = request.args.get('password', type=str)
 
     if not ics_url:
         return jsonify({"error": "No URL provided"}), 400
@@ -31,9 +36,12 @@ def calendar_data():
             lookback_days=lookback_days,
             horizon_days=horizon_days,
             limit=limit,
-            include_ended=False
+            include_ended=False,
+            username=auth_user,
+            password=auth_pass
         )
     except Exception as e:
+        traceback.print_exception(e)
         return jsonify({"error": f"Failed to retrieve events: {str(e)}"}), 400
 
     return jsonify({"events": events_out})

--- a/service.py
+++ b/service.py
@@ -194,7 +194,7 @@ def sort_and_limit(enriched: List[ParsedEvent], limit: Optional[int]) -> List[Pa
     return enriched
 
 
-def get_events(url: str, lookback_days: int, horizon_days: int, limit: Optional[int], username: Optional[str], password: Optional[str], include_ended=False, ) -> List[ParsedEvent]:
+def get_events(url: str, lookback_days: int, horizon_days: int, limit: Optional[int], username: Optional[str], password: Optional[str], include_ended=False) -> List[ParsedEvent]:
     now_utc = datetime.datetime.now(pytz.utc)
     start = now_utc - datetime.timedelta(days=lookback_days)
     end = now_utc + datetime.timedelta(days=horizon_days)


### PR DESCRIPTION
Currently cannot use authenticated icals from services like Radicale, add a basic auth header implementation, which ended up also ended up adjusting the system to grab the ical file itself instead of relying on ICalDownloader to do it, hopefully reducing overhead when fallbacks are involved.