### PR TITLE
Potential fix for code scanning alert no. 7: Information exposure through an exception

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -1,7 +1,9 @@
+import logging
 from flask import Flask, jsonify, request
 from service import get_events, clamp_int
 
 app = Flask(__name__)
+logger = logging.getLogger(__name__)
 
 
 
@@ -37,8 +39,9 @@ def calendar_data():
             username=auth_user,
             password=auth_pass
         )
-    except Exception as e:
-        return jsonify({"error": f"Failed to retrieve events: {str(e)}"}), 400
+    except Exception:
+        logger.exception("Failed to retrieve events")
+        return jsonify({"error": "Failed to retrieve events"}), 400
 
     return jsonify({"events": events_out})
 


### PR DESCRIPTION
Potential fix for [https://github.com/AWildLeon/Glance-iCal-Events/security/code-scanning/7](https://github.com/AWildLeon/Glance-iCal-Events/security/code-scanning/7)

To fix this, stop returning exception details to clients and log the exception server-side instead.

Best minimal fix in `src/app.py`:
- Add a standard logger import (`import logging`) and initialize a module logger.
- In the `except` block (lines 40–41 region), replace the response containing `str(e)` with:
  - server-side logging using `logger.exception(...)` (captures stack trace),
  - a generic error message in JSON for the client (no internal details).

This preserves behavior (request still fails cleanly) while removing sensitive information disclosure.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
